### PR TITLE
Add support for multiple devices

### DIFF
--- a/wishbone-tool/src/config.rs
+++ b/wishbone-tool/src/config.rs
@@ -38,6 +38,14 @@ pub fn get_base(value: &str) -> (&str, u32) {
     }
 }
 
+pub fn parse_u8(value: &str) -> Result<u8, ConfigError> {
+    let (value, base) = get_base(value);
+    match u8::from_str_radix(value, base) {
+        Ok(o) => Ok(o),
+        Err(e) => Err(ConfigError::NumberParseError(value.to_owned(), e)),
+    }
+}
+
 pub fn parse_u16(value: &str) -> Result<u16, ConfigError> {
     let (value, base) = get_base(value);
     match u16::from_str_radix(value, base) {
@@ -57,6 +65,8 @@ pub fn parse_u32(value: &str) -> Result<u32, ConfigError> {
 pub struct Config {
     pub usb_pid: Option<u16>,
     pub usb_vid: Option<u16>,
+    pub usb_bus: Option<u8>,
+    pub usb_device: Option<u8>,
     pub memory_address: Option<u32>,
     pub memory_value: Option<u32>,
     pub server_kind: ServerKind,
@@ -91,6 +101,19 @@ impl Config {
         } else {
             None
         };
+
+        let usb_bus = if let Some(bus) = matches.value_of("bus") {
+            Some(parse_u8(bus)?)
+        } else {
+            None
+        };
+
+        let usb_device = if let Some(device) = matches.value_of("device") {
+            Some(parse_u8(device)?)
+        } else {
+            None
+        };
+        // TODO: add parsing for bus and address here
 
         let serial_port = if let Some(port) = matches.value_of("serial") {
             bridge_kind = BridgeKind::UartBridge;
@@ -194,6 +217,8 @@ impl Config {
             Ok(Config {
                 usb_pid,
                 usb_vid,
+                usb_bus,
+                usb_device,
                 serial_port,
                 serial_baud,
                 spi_pins,

--- a/wishbone-tool/src/main.rs
+++ b/wishbone-tool/src/main.rs
@@ -32,10 +32,14 @@ fn list_usb() -> Result<(), libusb::Error> {
     println!("devices:");
     for device in devices.iter() {
         let device_desc = device.device_descriptor().unwrap();
+        let usb_bus = device.bus_number();
+        let usb_device = device.address();
         let mut line = format!(
-            "[{:04x}:{:04x}] - ",
+            "[{:04x}:{:04x}] usb: {:03}/{:03} - ",
             device_desc.vendor_id(),
-            device_desc.product_id()
+            device_desc.product_id(),
+            usb_bus,
+            usb_device,
         );
         if let Ok(usb) = device.open() {
             if let Ok(langs) = usb.read_languages(Duration::from_secs(1)) {
@@ -101,6 +105,24 @@ fn main() {
                 .value_name("USB_VID")
                 .help("USB VID to match")
                 .display_order(3)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("bus")
+                .short("B")
+                .long("bus")
+                .value_name("USB_BUS")
+                .help("USB BUS to match")
+                .display_order(4)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("device")
+                .short("d")
+                .long("device")
+                .value_name("USB_DEVICE")
+                .help("USB DEVICE to match")
+                .display_order(4)
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
I noticed that there was no way to use this tool for multiple devices with the same product and vendor id.
So I added an option to pass USB bus and device ids to commands.

I wasn't sure about the arg names so I named them
  * -B for bus
  * -d for device
I also added bus and device Ids in the list command output