### PR TITLE
Allow build of etherbone/litex-devmem2 on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 CFLAGS = -O0 -Wall -ggdb2
+CC?= gcc
 
 all: litex-devmem2
 
 etherbone.o: etherbone.c etherbone.h
-	gcc -c $(CFLAGS) etherbone.c -o etherbone.o
+	${CC} -c $(CFLAGS) etherbone.c -o etherbone.o
 
 litex-devmem2.o: litex-devmem2.c etherbone.h
-	gcc -c $(CFLAGS) litex-devmem2.c -o litex-devmem2.o
+	${CC} -c $(CFLAGS) litex-devmem2.c -o litex-devmem2.o
 
 litex-devmem2: etherbone.o litex-devmem2.o
-	gcc $(CFLAGS) etherbone.o litex-devmem2.o -o litex-devmem2
+	${CC} $(CFLAGS) etherbone.o litex-devmem2.o -o litex-devmem2
 
 clean:
 	rm -f etherbone.o litex-devmem2.o

--- a/etherbone.c
+++ b/etherbone.c
@@ -1,5 +1,9 @@
-#include <stdio.h>
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
+#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>


### PR DESCRIPTION
Work is in progress to decide how to handle the libusb layer, because I guess we just normally shim the standard libusb interface to ours and libusb proper has never been ported to FreeBSD.