### PR TITLE
libusb-sys: build native libusb on FreeBSD

### DIFF
--- a/wishbone-tool/libusb-sys/build.rs
+++ b/wishbone-tool/libusb-sys/build.rs
@@ -14,15 +14,16 @@ fn main() {
 
 pub fn compile_native_libusb() {
 	let mut base_config = cc::Build::new();
+	let src_base = var("SRC_BASE").unwrap_or("/usr/src".to_string());
 
-	base_config.file("/usr/src/lib/libusb/libusb20.c");
-	base_config.file("/usr/src/lib/libusb/libusb20_desc.c");
-	base_config.file("/usr/src/lib/libusb/libusb20_ugen20.c");
+	base_config.file(format!("{}{}", src_base, "/lib/libusb/libusb20.c"));
+	base_config.file(format!("{}{}", src_base, "/lib/libusb/libusb20_desc.c"));
+	base_config.file(format!("{}{}", src_base, "/lib/libusb/libusb20_ugen20.c"));
 
-	base_config.file("/usr/src/lib/libusb/libusb10.c");
-	base_config.file("/usr/src/lib/libusb/libusb10_desc.c");
-	base_config.file("/usr/src/lib/libusb/libusb10_hotplug.c");
-	base_config.file("/usr/src/lib/libusb/libusb10_io.c");
+	base_config.file(format!("{}{}", src_base, "/lib/libusb/libusb10.c"));
+	base_config.file(format!("{}{}", src_base, "/lib/libusb/libusb10_desc.c"));
+	base_config.file(format!("{}{}", src_base, "/lib/libusb/libusb10_hotplug.c"));
+	base_config.file(format!("{}{}", src_base, "/lib/libusb/libusb10_io.c"));
 	base_config.compile("libusb.a");
 }
 

--- a/wishbone-tool/libusb-sys/build.rs
+++ b/wishbone-tool/libusb-sys/build.rs
@@ -4,6 +4,29 @@ use std::env::var;
 
 fn main() {
 	let target_os = var("CARGO_CFG_TARGET_OS").unwrap();
+
+	if target_os == "freebsd" {
+		compile_native_libusb();
+	} else {
+		compile_libusb(&target_os);
+	}
+}
+
+pub fn compile_native_libusb() {
+	let mut base_config = cc::Build::new();
+
+	base_config.file("/usr/src/lib/libusb/libusb20.c");
+	base_config.file("/usr/src/lib/libusb/libusb20_desc.c");
+	base_config.file("/usr/src/lib/libusb/libusb20_ugen20.c");
+
+	base_config.file("/usr/src/lib/libusb/libusb10.c");
+	base_config.file("/usr/src/lib/libusb/libusb10_desc.c");
+	base_config.file("/usr/src/lib/libusb/libusb10_hotplug.c");
+	base_config.file("/usr/src/lib/libusb/libusb10_io.c");
+	base_config.compile("libusb.a");
+}
+
+pub fn compile_libusb(target_os: &str) {
 	let target_family = var("CARGO_CFG_TARGET_FAMILY").unwrap();
 	let target_env = var("CARGO_CFG_TARGET_ENV").unwrap();
 	let target_triple = var("TARGET").unwrap();


### PR DESCRIPTION
FreeBSD maintains a libusb that is compatible with the libusb used
everywhere else. Upstream for libusb-sys uses pkgconf for this, which
'just works' and grabs -lusb from the base system.

Further research after my previous PR seems to indicate that wishbone-tool specifically vendored libusb in the libusb-sys build, so add the build glue for FreeBSD libusb to
the build. With this, wishbone-tool can successfully build.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>