### PR TITLE
Modernize rust code in wishbone-tool

### DIFF
--- a/wishbone-tool/libusb-rs/src/device.rs
+++ b/wishbone-tool/libusb-rs/src/device.rs
@@ -31,30 +31,30 @@ unsafe impl<'a> Sync for Device<'a> {}
 impl<'a> Device<'a> {
     /// Reads the device descriptor.
     pub fn device_descriptor(&self) -> ::Result<DeviceDescriptor> {
-        let mut descriptor: libusb_device_descriptor = unsafe { mem::uninitialized() };
+        let mut descriptor = mem::MaybeUninit::<libusb_device_descriptor>::uninit();
 
         // since libusb 1.0.16, this function always succeeds
-        try_unsafe!(libusb_get_device_descriptor(self.device, &mut descriptor));
+        try_unsafe!(libusb_get_device_descriptor(self.device, descriptor.as_mut_ptr()));
 
-        Ok(device_descriptor::from_libusb(descriptor))
+        Ok(device_descriptor::from_libusb(unsafe { descriptor.assume_init() }))
     }
 
     /// Reads a configuration descriptor.
     pub fn config_descriptor(&self, config_index: u8) -> ::Result<ConfigDescriptor> {
-        let mut config: *const libusb_config_descriptor = unsafe { mem::uninitialized() };
+        let mut config = mem::MaybeUninit::<*const libusb_config_descriptor>::uninit();
 
-        try_unsafe!(libusb_get_config_descriptor(self.device, config_index, &mut config));
+        try_unsafe!(libusb_get_config_descriptor(self.device, config_index, config.as_mut_ptr()));
 
-        Ok(unsafe { config_descriptor::from_libusb(config) })
+        Ok(unsafe { config_descriptor::from_libusb(config.assume_init()) })
     }
 
     /// Reads the configuration descriptor for the current configuration.
     pub fn active_config_descriptor(&self) -> ::Result<ConfigDescriptor> {
-        let mut config: *const libusb_config_descriptor = unsafe { mem::uninitialized() };
+        let mut config = mem::MaybeUninit::<*const libusb_config_descriptor>::uninit();
 
-        try_unsafe!(libusb_get_active_config_descriptor(self.device, &mut config));
+        try_unsafe!(libusb_get_active_config_descriptor(self.device, config.as_mut_ptr()));
 
-        Ok(unsafe { config_descriptor::from_libusb(config) })
+        Ok(unsafe { config_descriptor::from_libusb(config.assume_init() ) })
     }
 
     /// Returns the number of the bus that the device is connected to.
@@ -80,11 +80,11 @@ impl<'a> Device<'a> {
 
     /// Opens the device.
     pub fn open(&self) -> ::Result<DeviceHandle<'a>> {
-        let mut handle: *mut libusb_device_handle = unsafe { mem::uninitialized() };
+        let mut handle = std::mem::MaybeUninit::<*mut libusb_device_handle>::uninit();
 
-        try_unsafe!(libusb_open(self.device, &mut handle));
+        try_unsafe!(libusb_open(self.device, handle.as_mut_ptr()));
 
-        Ok(unsafe { device_handle::from_libusb(self.context, handle) })
+        Ok(unsafe { device_handle::from_libusb(self.context, handle.assume_init() ) })
     }
 }
 

--- a/wishbone-tool/libusb-rs/src/device_handle.rs
+++ b/wishbone-tool/libusb-rs/src/device_handle.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::mem;
 use std::slice;
 use std::time::Duration;
 
@@ -41,7 +40,7 @@ unsafe impl<'a> Sync for DeviceHandle<'a> {}
 impl<'a> DeviceHandle<'a> {
     /// Returns the active configuration number.
     pub fn active_configuration(&self) -> ::Result<u8> {
-        let mut config = unsafe { mem::uninitialized() };
+        let mut config : i32 = 0;
 
         try_unsafe!(libusb_get_configuration(self.handle, &mut config));
         Ok(config as u8)
@@ -142,7 +141,7 @@ impl<'a> DeviceHandle<'a> {
             return Err(Error::InvalidParam);
         }
 
-        let mut transferred: c_int = unsafe { mem::uninitialized() };
+        let mut transferred: c_int = 0;
 
         let ptr = buf.as_mut_ptr() as *mut c_uchar;
         let len = buf.len() as c_int;
@@ -188,7 +187,7 @@ impl<'a> DeviceHandle<'a> {
             return Err(Error::InvalidParam);
         }
 
-        let mut transferred: c_int = unsafe { mem::uninitialized() };
+        let mut transferred: c_int = 0;
 
         let ptr = buf.as_ptr() as *mut c_uchar;
         let len = buf.len() as c_int;
@@ -236,7 +235,7 @@ impl<'a> DeviceHandle<'a> {
             return Err(Error::InvalidParam);
         }
 
-        let mut transferred: c_int = unsafe { mem::uninitialized() };
+        let mut transferred: c_int = 0;
 
         let ptr = buf.as_mut_ptr() as *mut c_uchar;
         let len = buf.len() as c_int;
@@ -282,7 +281,7 @@ impl<'a> DeviceHandle<'a> {
             return Err(Error::InvalidParam);
         }
 
-        let mut transferred: c_int = unsafe { mem::uninitialized() };
+        let mut transferred : c_int = 0;
 
         let ptr = buf.as_ptr() as *mut c_uchar;
         let len = buf.len() as c_int;
@@ -407,12 +406,12 @@ impl<'a> DeviceHandle<'a> {
             slice::from_raw_parts_mut((&mut buf[..]).as_mut_ptr(), buf.capacity())
         };
 
-        let len = try!(self.read_control(request_type(Direction::In, RequestType::Standard, Recipient::Device),
+        let len = self.read_control(request_type(Direction::In, RequestType::Standard, Recipient::Device),
                                          LIBUSB_REQUEST_GET_DESCRIPTOR,
                                          (LIBUSB_DT_STRING as u16) << 8,
                                          0,
                                          buf_slice,
-                                         timeout));
+                                         timeout)?;
 
         unsafe {
             buf.set_len(len);
@@ -434,12 +433,12 @@ impl<'a> DeviceHandle<'a> {
             slice::from_raw_parts_mut((&mut buf[..]).as_mut_ptr(), buf.capacity())
         };
 
-        let len = try!(self.read_control(request_type(Direction::In, RequestType::Standard, Recipient::Device),
+        let len = self.read_control(request_type(Direction::In, RequestType::Standard, Recipient::Device),
                                          LIBUSB_REQUEST_GET_DESCRIPTOR,
                                          (LIBUSB_DT_STRING as u16) << 8 | index as u16,
                                          language.lang_id(),
                                          buf_slice,
-                                         timeout));
+                                         timeout)?;
 
         unsafe {
             buf.set_len(len);

--- a/wishbone-tool/src/riscv/exception.rs
+++ b/wishbone-tool/src/riscv/exception.rs
@@ -60,7 +60,7 @@ pub enum RiscvException {
 
     /// 0 6
     StoreAddressMisaligned(u32 /* mepc */, u32 /* target address */),
-    
+
     /// 0 7
     StoreAccessFault(u32 /* mepc */, u32 /* target address */),
 
@@ -174,7 +174,7 @@ impl RiscvException {
             15 => StorePageFault(mepc, mtval),
             x @ 10 |
             x @ 14 |
-            x @ 15 ..= 0x7fffffff => ReservedFault(x, mepc, mtval),
+            x @ 16 ..= 0x7fffffff => ReservedFault(x, mepc, mtval),
         }
     }
 }


### PR DESCRIPTION
I cleaned up the usages of uninitialized pointers to remove the deprecation warnings about mem::uninitialized. I just initialized the uninitialized c_int return value variables to 0 -- it seemed a little pointless to try and leave those uninitialized.