### PR TITLE
ci: point to FreeBSD headers

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,6 +5,8 @@ set -ex
 # TODO This is the "test phase", tweak it as you see fit
 main() {
     cd wishbone-tool
+
+    export CI_FREEBSD_HEADERS=/usr/include/freebsd
     cross build --target $TARGET
     cross build --target $TARGET --release
 

--- a/wishbone-tool/libusb-sys/build.rs
+++ b/wishbone-tool/libusb-sys/build.rs
@@ -15,7 +15,12 @@ fn main() {
 pub fn compile_native_libusb() {
 	let mut base_config = cc::Build::new();
 	let src_base = var("SRC_BASE").unwrap_or("freebsd".to_string());
+	let headers = var("CI_FREEBSD_HEADERS").unwrap_or("".to_string());
 
+	if headers != "" {
+			base_config.include(headers);
+			base_config.include("/usr/include");
+	}
 	base_config.file(format!("{}{}", src_base, "/lib/libusb/libusb20.c"));
 	base_config.file(format!("{}{}", src_base, "/lib/libusb/libusb20_desc.c"));
 	base_config.file(format!("{}{}", src_base, "/lib/libusb/libusb20_ugen20.c"));


### PR DESCRIPTION
This will hopefully allow the FreeBSD libusb build to locate the proper
headers to build against now that freebsd_glue is installed.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>

(I suspect not merging yet is a good idea, since I can't trigger a Travis build against my branch)